### PR TITLE
Update updateDaily.py

### DIFF
--- a/updateDaily.py
+++ b/updateDaily.py
@@ -202,6 +202,9 @@ def update_resume() -> dict:
             profile_url,
             headers={
                 "accept": "application/json",
+                "appid": "105",
+                "systemid": "Naukri",
+                "clientid": "d3skt0p",
                 "authorization": f"Bearer {token}",
                 "content-type": "application/json",
                 "origin": "https://www.naukri.com",


### PR DESCRIPTION
Hi! Naukri recently updated their APIs and the advResume endpoint now returns a 401 Unauthorized error without these three headers. I've added them in to fix the profile update step.